### PR TITLE
Add transaction link in WC admin

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 4.3.0
+* Add transaction link in WC admin
+* Add details of failed transactions
+
 Version 4.2.0
 * Add ip verification of incoming callbacks
 * Add `swedbank_gateway_ip_addresses` wp filter

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,6 @@
         "php": ">=7.0",
         "adci/full-name-parser": "^0.2.4",
         "ramsey/uuid": "^3.7",
-        "swedbank-pay/swedbank-pay-woocommerce-core": "~4.1.0"
+        "swedbank-pay/swedbank-pay-woocommerce-core": "~4.1.1"
     }
 }

--- a/includes/class-wc-gateway-swedbank-pay-cc.php
+++ b/includes/class-wc-gateway-swedbank-pay-cc.php
@@ -992,6 +992,27 @@ class WC_Gateway_Swedbank_Pay_Cc extends WC_Payment_Gateway {
 	}
 
 	/**
+	 * Get the transaction URL.
+	 *
+	 * @param  WC_Order $order Order object.
+	 * @return string
+	 */
+	public function get_transaction_url( $order ) {
+		$payment_id = $order->get_meta( '_payex_payment_id' );
+		if ( empty( $payment_id ) ) {
+			return parent::get_transaction_url( $order );
+		}
+
+		if ( 'yes' === $this->testmode ) {
+			$view_transaction_url = 'https://admin.externalintegration.payex.com/psp/beta/payments/details;id=%s';
+		} else {
+			$view_transaction_url = 'https://admin.payex.com/psp/beta/payments/details;id=%s';
+		}
+
+		return sprintf( $view_transaction_url, urlencode( $payment_id ) );
+	}
+
+	/**
 	 * Process Payment
 	 *
 	 * @param int $order_id

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swedbank-pay-woocommerce-payments",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "",
   "main": "gulpfile.js",
   "dependencies": {

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ This plugin provides the Swedbank Pay Payments Gateway for WooCommerce.
 * Requires at least: 5.3
 * Tested up to: 5.6
 * Requires PHP: 7.0
-* Stable tag: 4.2.0
+* Stable tag: 4.3.0
 * [License: Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
 ## Description

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: swedbankpay
 Tags: ecommerce, e-commerce, commerce, woothemes, wordpress ecommerce, swedbank, payex, payment gateway
 Requires at least: 5.3
 Tested up to: 5.6
-Stable tag: 4.2.0
+Stable tag: 4.3.0
 License: Apache License 2.0
 License URI: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/swedbank-pay-woocommerce-payments.php
+++ b/swedbank-pay-woocommerce-payments.php
@@ -7,11 +7,11 @@
  * Author URI: https://profiles.wordpress.org/swedbankpay/
  * License: Apache License 2.0
  * License URI: http://www.apache.org/licenses/LICENSE-2.0
- * Version: 4.2.0
+ * Version: 4.3.0
  * Text Domain: swedbank-pay-woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 5.5.1
- * WC tested up to: 5.5.1
+ * WC tested up to: 5.5.2
  */
 
 use SwedbankPay\Payments\WooCommerce\WC_Swedbank_Plugin;

--- a/tests/unit-tests/wc-gateway-swedbank-pay-cc.php
+++ b/tests/unit-tests/wc-gateway-swedbank-pay-cc.php
@@ -190,4 +190,20 @@ class WC_Unit_Gateway_Swedbank_Pay_CC extends WC_Unit_Test_Case {
 		$this->assertArrayHasKey( 'order_id', $result );
 		$this->assertArrayHasKey( 'line_items', $result );
 	}
+
+	public function test_get_transaction_url() {
+		/** @var WC_Order $order */
+		$order  = WC_Helper_Order::create_order();
+		$order->set_payment_method( $this->gateway );
+		$order->set_currency( 'SEK' );
+		$order->save();
+
+		// Save payment ID
+		$order->update_meta_data( '_payex_payment_id', '/psp/test' );
+		$order->save_meta_data();
+
+		$result = $this->gateway->get_transaction_url( $order );
+
+		$this->assertContains('https', $result);
+	}
 }


### PR DESCRIPTION
Adds the link in order view of WC admin.
https://admin.externalintegration.payex.com/psp/beta/ or
https://admin.payex.com/psp/beta/
![ScreenshotZ1](https://user-images.githubusercontent.com/6286270/127811862-57c23db7-ef72-4f3a-b540-2879d9627d43.png)
