### PR TITLE
Remove deprecated `merge: strict` from Mergify.yml

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -9,10 +9,11 @@ pull_request_rules:
   - name: Automatic merge on approval
     conditions:
       - author~=^dependabot(|-preview)\[bot\]$
+      - '#commits-behind=0' # Only merge up to date pull requests
+      - check-success=Run tests
+      - check-success=license/cla
     actions:
       merge:
-        method: merge
-        strict: smart
 
   - name: Thank contributor
     conditions:


### PR DESCRIPTION
Remove `merge: strict` from the Mergify configuration because it is [deprecated](https://blog.mergify.com/strict-mode-deprecation/):

> The configuration uses the deprecated strict mode of the merge action.
> A brownout is planned for the whole December 6th, 2021 day.
> This option will be removed on January 10th, 2022.

Once merged, the Mergify check should turn green on `main`.