### PR TITLE
Add new callback addresses that will be used form March 12, 2025.

### DIFF
--- a/includes/class-wc-gateway-swedbank-pay-cc.php
+++ b/includes/class-wc-gateway-swedbank-pay-cc.php
@@ -156,7 +156,18 @@ class WC_Gateway_Swedbank_Pay_Cc extends WC_Payment_Gateway {
 	 * Swedbank Pay ip addresses
 	 * @var array
 	 */
-	public $gateway_ip_addresses = [ '91.132.170.1' ];
+	public $gateway_ip_addresses = [
+        '20.91.170.120',
+        '20.91.170.121',
+        '20.91.170.122',
+        '20.91.170.123',
+        '20.91.170.124',
+        '20.91.170.125',
+        '20.91.170.126',
+        '20.91.170.127',
+        '51.107.183.58',
+        '91.132.170.1'
+    ];
 
 	/**
 	 * Init


### PR DESCRIPTION
According to [communication from Swedbank](https://developer.stage.swedbankpay.com/checkout-v3/features/payment-operations/callback/#faq--change-of-ip-addresses-for-callbacks), the IP addresses used for making callbacks will change starting March 12, 2025. Unfortunately this plugin does not support changing these addresses in WP-admin UI so I created a PR to change the class instead. This PR contains both old and new addresses and can therefor be used directly.